### PR TITLE
Avoid an error when loading in non-Node envs

### DIFF
--- a/lib/memo-is.js
+++ b/lib/memo-is.js
@@ -108,7 +108,7 @@ var Memoizer = function() {
   memoizer.is = this.is;
 };
 
-if (module && module.exports) { // Node.js
+if (typeof(module) != 'undefined' && module.exports) { // Node.js
   /**
    * Return a new Memoizer object.
    *


### PR DESCRIPTION
Otherwise, this reference to `module` causes:

```
ReferenceError: module is not defined
```
