### PR TITLE
Allow constant values to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/memo-is.js
+++ b/lib/memo-is.js
@@ -99,6 +99,10 @@ var Memoizer = function() {
 
   /** Push a new function to the memoizer stack for the current example group */
   this.is = function(callback) {
+    if (!(callback instanceof Function)) {
+      const value = callback;
+      callback = () => value;
+    }
     before(push(callback));
     afterEach(reset);
     after(pop);

--- a/test/memo-is-test.js
+++ b/test/memo-is-test.js
@@ -53,4 +53,13 @@ describe('Memoizer', function(){
       });
     });
   });
+
+  describe('can be used with values iso objects', function() {
+      example.is(['bob']);
+
+      it('returns the overridden value', function(){
+          assert.equal(example()[0], 'bob');
+      });
+
+  })
 });


### PR DESCRIPTION
This makes the syntax a bit cleaner.
You can now use: 
```
     example.is(['bob']);
```
iso
```
    example.is(function() { return ['bob']; });
```
or
```
    example.is(() =>['bob']);
```
